### PR TITLE
add UTC representation( IST ) for local time of india

### DIFF
--- a/client/src/Components/CompetitionItem.js
+++ b/client/src/Components/CompetitionItem.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { timeLeft } from "../helpers/TimeLeft";
 
+
 export default function CompetitionItem({ item, index }) {
   const returnHours = (e) => {
     return Math.floor(e / 60);
@@ -24,6 +25,24 @@ export default function CompetitionItem({ item, index }) {
     competition_name,
   } = item;
 
+  const months = {
+    0: 'Jan',
+    1: 'Feb',
+    2: 'Mar',
+    3: 'Apr',
+    4: 'May',
+    5: 'Jun',
+    6: 'Jul',
+    7: 'Aug',
+    8: 'Sep',
+    9: 'Oct',
+    10: 'Nov',
+    11: 'Dec'
+  }
+
+
+  // const regionalTime = timeConvertor( competition_date , time_start_mins );
+
   const isRegistrationStarted =
     timeLeft(false, registration_start_date, registration_start_time_mins) ===
     "Expired";
@@ -35,7 +54,7 @@ export default function CompetitionItem({ item, index }) {
   const isCompetitionStarted =
     timeLeft(false, competition_date, time_start_mins) === "Expired";
 
-  const showTimeLeftToCompetition = () =>
+  const showTimeLeftToCompetition = () => 
     timeLeft(false, competition_date, time_start_mins);
 
   const showTimeLeftToCompetitionEnd = () =>
@@ -46,6 +65,12 @@ export default function CompetitionItem({ item, index }) {
 
   const showTimeLeftToRegistrationEnd = () =>
     timeLeft(false, registration_end_date, registration_end_time_mins);
+  
+  const getIST = () =>{
+    const ISTString =  `${ competition_date } ${ returnHours(time_start_mins).toString()}:${ returnMins(time_start_mins).toString()}:00 GMT+0530`;
+    console.log( ISTString);
+    return new Date( ISTString );     
+  }  
 
   return (
     <div
@@ -61,26 +86,21 @@ export default function CompetitionItem({ item, index }) {
       </div>
       <div className="date">
         <div className="date-show">
-          {competition_date},{" "}
+         { months[ getIST().getMonth() ] + " " + getIST().getDate() + " " + getIST().getFullYear() + " "}
+        
           <>
-            {returnHours(time_start_mins) < 10 ? (
-              <>
-                {"0"}
-                {returnHours(time_start_mins)}
-              </>
+            {( getIST().getHours() ) < 10 ? (
+              <>{`0${ getIST().getHours() }`}</>
             ) : (
-              <>{returnHours(time_start_mins)}</>
+              <>{ getIST().getHours() }</>
             )}
           </>
           :
           <>
-            {returnMins(time_start_mins) < 10 ? (
-              <>
-                {"0"}
-                {returnMins(time_start_mins)}
-              </>
+            { getIST().getMinutes() < 10 ? (
+              <>{`0${ getIST().getMinutes() }`}</>
             ) : (
-              <>{returnMins(time_start_mins)}</>
+              <>{ getIST().getMinutes() }</>
             )}
           </>
           {}

--- a/client/src/helpers/TimeLeft.js
+++ b/client/src/helpers/TimeLeft.js
@@ -3,7 +3,7 @@ export const timeLeft = (num, date, minutes) => {
 
   (() => {
     const now = new Date();
-    const eventDate = new Date(date);
+    const eventDate = new Date( `${ date } 00:00:00 GMT+0530` );
     const currentTime = now.getTime();
     const eventTime = eventDate.getTime();
     const remTime = eventTime - currentTime;


### PR DESCRIPTION
I added a new function named `getIST()` which returns the UTC representation of local Indian time. I also change the `timeLeft` component in TimeLeft.js to represent the local Indian time as UTC time.

for example, Jan 12 2023 8:30:00 GMT+0530 UTC is the UTC/GMT representation of the local Indian time "Jan 12, 2023"  in API.
Minutes are also added. 

Initially, tried to change every date and time into milliseconds and then to UTC time. However, this approach results in an error in the output.  Therefore, the `getIST()` function converts a string representation of UTC to Date and returns this Date.

I tested with online tools such as https://www.timeanddate.com/date/timeduration.html to check the time left. It looks to me output in the table matches the output given by this tool. If there is any difference it is in a few minutes( 1 or 2-minute difference ) 

I also use this tool https://www.freeconvert.com/time/ist-to-utc