### PR TITLE
fix: Changed modal.css classname

### DIFF
--- a/client/src/Allcss/Modal.css
+++ b/client/src/Allcss/Modal.css
@@ -99,7 +99,7 @@
   opacity: 0;
   transform: translateY(-100%);
 } */
-.btn{
+.modal-btn{
   padding: 0.25rem; 
   border: none;
   transition: opacity 0.3s ease;
@@ -108,7 +108,7 @@
   cursor: pointer;
 }
  
-  .body{
+  .modal-body{
     display: flex;
   position: relative;
   padding: 1.5rem; 

--- a/client/src/MicroComponents/Allmodals/Modal.jsx
+++ b/client/src/MicroComponents/Allmodals/Modal.jsx
@@ -20,13 +20,13 @@ export const Modal = ({ isOpen, body, footer, label, onClose }) => {
               className={`boxmodal ${showModal ? 'show-modal' : 'hide-modal'}`}
            
             >
-              <button className="btn" onClick={onClose}>
+              <button className="modal-btn" onClick={onClose}>
                 <IoMdClose size={18} />
               </button>
               <div className="custom-text">{label}</div>
             </div>
             {/*body*/}
-            <div className="body">{body}</div>
+            <div className="modal-body">{body}</div>
             {/*footer*/}
             <div className="biggerfooter">
               <div


### PR DESCRIPTION
# What does this PR do?
This PR fixed the ```Modal.css``` file my changing the class names of ```btn```to ```modal-btn ```and ```body``` to ```modal-body```

![image](https://github.com/Nayaker/AlgoListed/assets/108735151/796a6310-69f3-42a6-9d86-08b974c56442)

Fixes #114
## Type of Change
- Bug fix
