### PR TITLE
BugFix-CST questions mark options issue after refresh

### DIFF
--- a/client/src/DummyDB/CoreSubjects/OSquestions.json
+++ b/client/src/DummyDB/CoreSubjects/OSquestions.json
@@ -173,5 +173,12 @@
         "answer": "Different scheduling algorithms govern the execution order of processes in operating systems. First Come First Serve (FCFS) serves processes in the order of arrival, while Round Robin (RR) allocates a fixed time quantum to each process, rotating through them. Shortest Job First (SJF) prioritizes the process with the shortest execution time. Priority Scheduling (PS) assigns priority values (nice values) to processes, and the one with the highest priority gets executed first. Each algorithm aims to optimize system performance based on specific criteria like turnaround time, response time, or prioritization.",
         "completed": false,
         "marked": false
+    },
+    {
+        "_id": "16-nov-2023-20'44-@IrfanSalim",
+        "quesName": "What is the purpose of the 'ls' command in Unix/Linux?",
+        "answer": "The 'ls' command in Unix/Linux is used to list the files and directories in the current working directory.",
+        "completed": false,
+        "marked": false
     }
 ]

--- a/client/src/Screen/CoreSubjectsTracker.js
+++ b/client/src/Screen/CoreSubjectsTracker.js
@@ -51,22 +51,35 @@ const CoreSubjectsTracker = () => {
     }, []);
 
     useEffect(() => {
-        const storedCompletedTopics = localStorage.getItem("completedTopics");
-        if (storedCompletedTopics) setSelectedLabels(JSON.parse(storedCompletedTopics));
+        try {
+            const storedCompletedTopics = JSON.parse(localStorage.getItem("completedTopics"));
 
-        const updatedData = data.map((item) => {
-            const completed = localStorage.getItem(`completedquestion-coresheet-${item._id}`);
-            const marked = localStorage.getItem(`markedquestion-coresheet-${item._id}`);
+            if (storedCompletedTopics) {
+                const updatedCompletedTopics = OSTopics
+                    .filter((item) => storedCompletedTopics.includes(item.name))
+                    .map((item) => item.name);
 
-            return {
-                ...item,
-                completed: completed === "true",
-                marked: marked == "true",
-            };
-        });
+                localStorage.setItem("completedTopics", JSON.stringify(updatedCompletedTopics));
+                setSelectedLabels([...updatedCompletedTopics]);
+            }
 
-        setFilteredData(updatedData);
-    }, [data])
+            const updatedData = data.map((item) => {
+                const completed = localStorage.getItem(`completedquestion-coresheet-${item._id}`);
+                const marked = localStorage.getItem(`markedquestion-coresheet-${item._id}`);
+
+                return {
+                    ...item,
+                    completed: completed === "true",
+                    marked: marked === "true",
+                };
+            });
+
+            setFilteredData(updatedData);
+        } catch (error) {
+            console.error("Error in useEffect:", error);
+        }
+    }, [data]);
+    
     
     const filters = coreSubjectsTrackerFilters.map((item) => {
         return (
@@ -102,7 +115,7 @@ const CoreSubjectsTracker = () => {
     };
 
     const toggleCompleted = (index) => {
-        const updatedData = [...data];
+        const updatedData = [...filteredData];
         
         updatedData[index].completed = !updatedData[index].completed;
 
@@ -111,12 +124,11 @@ const CoreSubjectsTracker = () => {
             updatedData[index].completed
         );
 
-        setData(updatedData);
-        filteredData(updatedData);
+        setFilteredData(updatedData);
     };
 
     const toggleMarked = (index) => {
-        const updatedData = [...data];
+        const updatedData = [...filteredData];
 
         updatedData[index].marked = !updatedData[index].marked;
 
@@ -125,7 +137,7 @@ const CoreSubjectsTracker = () => {
             updatedData[index].marked
         );
 
-        setData(updatedData);
+        setFilteredData(updatedData);
     }
 
     const allTopics = OSTopics;


### PR DESCRIPTION
For #210 

Fixed the bug and also addressed the same issue for Topics by removing any locally stored topic if it's not present in the source data.